### PR TITLE
Post all command line arguments as message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -39,7 +39,7 @@ machine = socket.gethostname()
 
 msg = "Done."
 if len(sys.argv) > 1:
-	msg = sys.argv[1]
+	msg = ' '.join(sys.argv[1:])
 
 r = requests.post(url, json = {'text': 'Job for user `{}` on machine `{}`: _{}_'.format(user, machine, msg), 'channel': '#servers'})
 


### PR DESCRIPTION
With this change, all arguments to jobbot are considered as the message
to post, not only the first one. This saves us from having to escape
spaces in the message.

Old behavior:
$ jobbot Hello world
posts "Hello"

New behavior:
$ jobbot Hello world
posts "Hello World"